### PR TITLE
Fix rounding nan issue.

### DIFF
--- a/saneround/saneround.py
+++ b/saneround/saneround.py
@@ -7,7 +7,7 @@ Numeric = Union[int, float]
 
 
 def round(number: Numeric, ndigits: int = 0) -> float:
-    if number in [math.inf, -math.inf, math.nan, 0.0]:
+    if (number == 0.0) or math.isinf(number) or math.isnan(number):
         return number
 
     _, num_binexp = math.frexp(number)

--- a/tests/test_round.py
+++ b/tests/test_round.py
@@ -34,10 +34,21 @@ class RoundTest(TestCase):
         self.assertEqual(sr.round(math.inf, -2), math.inf)
         self.assertEqual(sr.round(-math.inf, -2), -math.inf)
 
+        rounded = sr.round(math.inf * math.inf)
+        self.assertTrue(rounded > 0)
+        self.assertTrue(math.isinf(rounded))
+
+        rounded = sr.round(-math.inf * math.inf)
+        self.assertTrue(rounded < 0)
+        self.assertTrue(math.isinf(rounded))
+
     def test_round_nan(self) -> None:
         self.assertTrue(math.isnan(sr.round(math.nan)))
         self.assertTrue(math.isnan(sr.round(math.nan, 2)))
         self.assertTrue(math.isnan(sr.round(math.nan, -2)))
+
+        rounded = sr.round(math.nan * math.nan)
+        self.assertTrue(math.isnan(rounded))
 
     def test_ndigits(self) -> None:
         self.assertEqual(sr.round(5.5, 0), 6.0)


### PR DESCRIPTION
`np.nan in [math.nan]` returns `False`.
So I changed to use `math.isnan()` instead. (`math.isnan(np.nan)` returns `True`.)

close #3 